### PR TITLE
Cleaning apt-lists after apt commands

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update \
       imagemagick \
       make \
  && apt-get autoremove \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install -U pip
 RUN python3 -m pip install Sphinx==3.0.3 Pillow

--- a/latexpdf/Dockerfile
+++ b/latexpdf/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update \
       texlive-luatex \
       texlive-xetex \
  && apt-get autoremove \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install -U pip
 RUN python3 -m pip install Sphinx==3.0.3 Pillow


### PR DESCRIPTION
Removing the apt lists is convenient to avoid other dockerbuilds using this as a base to inherit stalled data, as well as reducing the resulting image size (nops, `apt clean` does not cover everything). That is also a recommendation from docker, see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run