### PR TITLE
Use additional directives for more compact images

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Sphinx Team <https://www.sphinx-doc.org/>"
 
 WORKDIR /docs
 RUN apt-get update \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
       graphviz \
       imagemagick \
       make \
@@ -11,7 +11,7 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install -U pip
-RUN python3 -m pip install Sphinx==3.1.2 Pillow
+RUN python3 -m pip install --no-cache-dir -U pip
+RUN python3 -m pip install --no-cache-dir Sphinx==3.1.2 Pillow
 
 CMD ["make", "html"]

--- a/latexpdf/Dockerfile
+++ b/latexpdf/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Sphinx Team <https://www.sphinx-doc.org/>"
 
 WORKDIR /docs
 RUN apt-get update \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
       graphviz \
       imagemagick \
       make \
@@ -22,7 +22,7 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install -U pip
-RUN python3 -m pip install Sphinx==3.1.2 Pillow
+RUN python3 -m pip install --no-cache-dir -U pip
+RUN python3 -m pip install --no-cache-dir Sphinx==3.1.2 Pillow
 
 CMD ["make", "latexpdf"]


### PR DESCRIPTION
Adding the below directives results in smaller layers and as such, a more compact image:
- Add '--no-cache-dir' to pip
- Add '--no-install-recommends' to apt-get

base
-----
### Original:
    166 MB  apt-get update && apt-get install -y …
     82 MB  python3 -m pip install Sphinx==3.1.2 Pillow

### With this PR:
    94 MB  apt-get update && apt-get install --no-install-recommends -y …
    64 MB  python3 -m pip install --no-cache-dir Sphinx==3.1.2 Pillow

Saving ~90 MBs in total for this image

latexpdf
--------
### Original:
    2.8 GB  apt-get update && apt-get install -y …
     82 MB  python3 -m pip install Sphinx==3.1.2 Pillow

### With this PR:
    2.0 GB  apt-get update && apt-get install --no-install-recommends -y ...
     64 MB  python3 -m pip install --no-cache-dir Sphinx==3.1.2 Pillow

Saving over 800 MBs in total for this image