### PR TITLE
Install fonts-freefont-otf in latexpdf image

### DIFF
--- a/latexpdf/Dockerfile
+++ b/latexpdf/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       \
       latexmk \
       lmodern \
+      fonts-freefont-otf \
       texlive-latex-recommended \
       texlive-latex-extra \
       texlive-fonts-recommended \


### PR DESCRIPTION
This is the default font for xelatex.

I previously only tested an old sphinx project, which has its own font settings. However the default one wants an extra font.

This can be tested with:

```
docker run --rm -v /path/to/document:/docs sphinxdoc/sphinx:latest sphinx-quickstart

# set language to zh-cn

docker run --rm -v /path/to/document:/docs sphinxdoc/sphinx-latexpdf:latest make latexpdf
```

error log

```
(/usr/share/texlive/texmf-dist/tex/generic/babel/xebabel.def
(/usr/share/texlive/texmf-dist/tex/generic/babel/txtbabel.def)))))kpathsea:make_tex: Invalid filename `[FreeSerif.otf]/OT', contains '['


! Package fontspec Error: The font "FreeSerif" cannot be found.
```