### PR TITLE
Add xindy dependency

### DIFF
--- a/latexpdf/Dockerfile
+++ b/latexpdf/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
       texlive-lang-japanese \
       texlive-luatex \
       texlive-xetex \
+      xindy \
  && apt-get autoremove \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
See https://github.com/sphinx-doc/sphinx/issues/8941.

This is untested, but the dependency `xindy` is part of the Debian repositories used by `python-slim`, and installing `xindy` via `apt` inside the docker image does work (and has been tested by me... you'll have to take my word for it).