### PR TITLE
README: run docker in interactive mode for sphinx-quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Note:
 Create a Sphinx project::
 
 ```bash
-$ docker run --rm -v /path/to/document:/docs sphinxdoc/sphinx sphinx-quickstart
+$ docker run -it --rm -v /path/to/document:/docs sphinxdoc/sphinx sphinx-quickstart
 ```
 
 Build HTML document::


### PR DESCRIPTION
If I run it without interactive mode I see the following:
```
> docker run --rm -v $PWD:/docs sphinxdoc/sphinx sphinx-quickstart
Welcome to the Sphinx 3.4.0 quickstart utility.

Please enter values for the following settings (just press Enter to
accept a default value, if one is given in brackets).

Selected root path: .

You have two options for placing the build directory for Sphinx output.
Either, you use a directory "_build" within the root path, or you separate
"source" and "build" directories within the root path.
> Separate source and build directories (y/n) [n]:
[Interrupted.]
```

Also add -t option to allocate a pseudo-TTY. Without this option there
are no colors in the terminal during sphinx-quickstart Q&A session.