### PR TITLE
Add tex-gyre dependency

### DIFF
--- a/latexpdf/Dockerfile
+++ b/latexpdf/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
       texlive-luatex \
       texlive-xetex \
       xindy \
+      tex-gyre \
  && apt-get autoremove \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Relates: https://github.com/sphinx-doc/docker-ci/pull/5

My build failed after updating because it could not find `tgtermes.sty`, so I added the `tex-gyre` dependency as in the CI image to fix the issue. 