### PR TITLE
refactor(latex): using fedora as base image

### DIFF
--- a/latexpdf/Dockerfile
+++ b/latexpdf/Dockerfile
@@ -1,32 +1,14 @@
-FROM python:slim
+FROM fedora
 LABEL maintainer="Sphinx Team <https://www.sphinx-doc.org/>"
 
 WORKDIR /docs
-RUN apt-get update \
- && apt-get install --no-install-recommends -y \
-      graphviz \
-      imagemagick \
-      make \
-      \
-      latexmk \
-      lmodern \
-      fonts-freefont-otf \
-      texlive-latex-recommended \
-      texlive-latex-extra \
-      texlive-fonts-recommended \
-      texlive-fonts-extra \
-      texlive-lang-cjk \
-      texlive-lang-chinese \
-      texlive-lang-japanese \
-      texlive-luatex \
-      texlive-xetex \
-      xindy \
-      tex-gyre \
- && apt-get autoremove \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-RUN python3 -m pip install --no-cache-dir -U pip
-RUN python3 -m pip install --no-cache-dir Sphinx==4.1.1 Pillow
+RUN echo -e 'assumeyes=True\ninstall_weak_deps=False\ntsflags=nodocs' >> /etc/dnf/dnf.conf \
+    # Install latex with Chinese support
+    && dnf in make latexmk texlive-{xetex,xindy,cmap,xecjk,gnu-freefont,fncychap,wrapfig,capt-of,framed,upquote,needspace,tabulary,parskip,fandol}\
+       pip \
+    && pip --no-cache-dir install setuptools
+    && pip install --no-cache-dir Sphinx Pillow
+    && dnf autoremove \
+    && dnf clean all
 
 CMD ["make", "latexpdf"]


### PR DESCRIPTION
Here is my docker build: https://registry.hub.docker.com/r/dragontao/sphinx_mermaid

A docker image with support of latex, mermaid, plantuml, needs, wavedrom and mscgen. And lang support for Chinese(Korea and jp has no test). It just 951.16 MB.
But sphinxdoc/sphinx-latexpdf:4.1.1 is 942.78 MB

So, I think may fedora is a better choice other than ubuntu

Full source code of my image is:
```
FROM fedora

ADD requirements.txt /root
ADD .devcontainer/puppeteer-config.json  /puppeteer-config.json
RUN echo -e 'assumeyes=True\ninstall_weak_deps=False\ntsflags=nodocs' >> /etc/dnf/dnf.conf \
    # install latex
    && dnf in make latexmk texlive-{xetex,xindy,cmap,xecjk,gnu-freefont,fncychap,wrapfig,capt-of,framed,upquote,needspace,tabulary,parskip,fandol}\
        # mscgen
        mscgen \
        # plantuml
        plantuml graphviz pip wqy-microhei-fonts\
    # mermaid 和 wavedrom
    && dnf in fedora-workstation-repositories \
    && sed 's/enabled=0/enabled=1/g' -i /etc/yum.repos.d/google-chrome.repo \
    && dnf in google-chrome-stable yarnpkg nodejs /usr/bin/pdfcrop ghostscript\
    && yarn global add @mermaid-js/mermaid-cli wavedrom-cli \
    # install pip
    && pip --no-cache-dir install setuptools \
    && pip --no-cache-dir install -r /root/requirements.txt \
    # clean
    && dnf autoremove \
    && dnf clean all
```