### PR TITLE
10159: build linux/amd64 and linux/arm64 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
             context: latexpdf
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -32,6 +34,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.context }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR address the issue https://github.com/sphinx-doc/sphinx/issues/10159
It creates multi-architecture docker images for linux/amd64 and linux/arm64, thus supporting Apple’s M1 processor.

Tested by building the docker images denisa/sphinx and using it to build our documentation site